### PR TITLE
feat: use chore commit type for all version updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -25,5 +25,13 @@
   },
   "baseBranches": ["develop"],
   "branchPrefix": "chore/dependencies/",
-  "rebaseWhen": "behind-base-branch"
+  "rebaseWhen": "behind-base-branch",
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "semanticCommitType": "chore"
+    }
+  ]
 }

--- a/java-group.json
+++ b/java-group.json
@@ -67,6 +67,13 @@
         "^com\\.apollographql\\.apollo"
       ],
       "matchDatasources": ["maven"]
+    },
+    {
+      "groupName": "com.github.twitch4j",
+      "matchPackagePatterns": [
+        "^com\\.github\\.twitch4j"
+      ],
+      "matchDatasources": ["maven"]
     }
   ]
 }


### PR DESCRIPTION
### Changes Proposed

* use prefix `chore(deps)` for all renovate version updates, minor updates are still commited with `fix(deps)` right now
* group `com.github.twitch4j` into a single PR for example projects