### PR TITLE
feat: support updating lombok version from gradle version.set

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,7 +12,8 @@
     ":pinVersions",
     "github>twitch4j/renovate-config:java-group",
     "github>twitch4j/renovate-config:java-javadocio",
-    "github>twitch4j/renovate-config:java-gradle-prefer"
+    "github>twitch4j/renovate-config:java-gradle-prefer",
+    "github>twitch4j/renovate-config:java-gradle-lombok"
   ],
   "labels": [
     "dependencies"

--- a/java-gradle-lombok.json
+++ b/java-gradle-lombok.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "regexManagers": [
+    {
+      "fileMatch": [
+        ".*\\.kts$"
+      ],
+      "datasourceTemplate": "maven",
+      "matchStrings": [
+        "// renovate: depName=(?<depName>.*?)\r?\n.*version.set\\(\"(?<currentValue>.*)\"\\)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [ ] I have tested this feature

### Changes Proposed

This should allow renovate to update the lombok version properly, by adding a `// renovate` comment

```
project.extensions.getByType(LombokExtension::class).apply {
    // renovate: depName=org.projectlombok:lombok
    version.set("1.18.26")
}
```
