### PR TITLE
feat: add missing sourceUrls and changelogUrls for some dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,9 @@
     "github>twitch4j/renovate-config:java-group",
     "github>twitch4j/renovate-config:java-javadocio",
     "github>twitch4j/renovate-config:java-gradle-prefer",
-    "github>twitch4j/renovate-config:java-gradle-lombok"
+    "github>twitch4j/renovate-config:java-gradle-lombok",
+    "github>twitch4j/renovate-config:java-changelog",
+    "github>twitch4j/renovate-config:java-gradleplugin-sourceurl"
   ],
   "labels": [
     "dependencies"

--- a/java-changelog.json
+++ b/java-changelog.json
@@ -14,7 +14,7 @@
     {
       "matchDatasources": ["maven"],
       "matchPackageNames": ["org.junit:junit-bom"],
-      "changelogUrl": "https://junit.org/junit5/docs/5.11.0/release-notes/"
+      "changelogUrl": "https://junit.org/junit5/docs/current/release-notes/"
     },
     {
       "matchDatasources": ["maven"],

--- a/java-changelog.json
+++ b/java-changelog.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchDatasources": ["maven"],
+      "matchPackagePatterns": ["^org\\.apache\\.commons:commons-lang3"],
+      "changelogUrl": "https://github.com/apache/commons-lang/blob/master/RELEASE-NOTES.txt"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["commons-io:commons-io"],
+      "changelogUrl": "https://github.com/apache/commons-io/blob/master/RELEASE-NOTES.txt"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["org.junit:junit-bom"],
+      "changelogUrl": "https://junit.org/junit5/docs/5.11.0/release-notes/"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["com.google.guava:guava"],
+      "sourceUrl": "https://github.com/google/guava"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["org.junit:junit-bom"],
+      "sourceUrl": "https://github.com/junit-team/junit5"
+    }
+  ]
+}

--- a/java-changelog.json
+++ b/java-changelog.json
@@ -14,17 +14,13 @@
     {
       "matchDatasources": ["maven"],
       "matchPackageNames": ["org.junit:junit-bom"],
+      "sourceUrl": "https://github.com/junit-team/junit5",
       "changelogUrl": "https://junit.org/junit5/docs/current/release-notes/"
     },
     {
       "matchDatasources": ["maven"],
       "matchPackageNames": ["com.google.guava:guava"],
       "sourceUrl": "https://github.com/google/guava"
-    },
-    {
-      "matchDatasources": ["maven"],
-      "matchPackageNames": ["org.junit:junit-bom"],
-      "sourceUrl": "https://github.com/junit-team/junit5"
     }
   ]
 }

--- a/java-gradleplugin-sourceurl.json
+++ b/java-gradleplugin-sourceurl.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": [
+        "me.philippheuer.configuration:me.philippheuer.configuration.gradle.plugin"
+      ],
+      "sourceUrl": "https://github.com/PhilippHeuer/gradle-projectconfiguration"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["io.freefair.gradle:lombok-plugin"],
+      "sourceUrl": "https://github.com/freefair/gradle-plugins"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": [
+        "org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin"
+      ],
+      "sourceUrl": "https://github.com/JetBrains/kotlin"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": [
+        "org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin"
+      ],
+      "sourceUrl": "https://github.com/Kotlin/dokka"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["com.gradleup.shadow:shadow-gradle-plugin"],
+      "sourceUrl": "https://github.com/GradleUp/shadow"
+    },
+    {
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["org.cyclonedx:cyclonedx-gradle-plugin"],
+      "sourceUrl": "https://github.com/CycloneDX/cyclonedx-gradle-plugin"
+    }
+  ]
+}


### PR DESCRIPTION
### Prerequisites for Code Changes

* [x] This pull request follows the code style of the project
* [x] I have tested this feature

### Changes Proposed

Most of the gradle plugins and some of the libraries we use don't provide the needed metadata for renovate to display the changelog, this provides a way for us to manually set the source repo or changelog url for those plugins / dependencies.

### Additional Information
